### PR TITLE
added map_location arg to torch.load

### DIFF
--- a/src/utils.py
+++ b/src/utils.py
@@ -104,10 +104,14 @@ def load_model(args, weights_loaded=True):
     if not weights_loaded:
         return model_ori
 
+    map_location = None
+    if args.device == 'cpu':
+        map_location = torch.device('cpu')
+
     if 'cnn_4layer' not in args.model:
-        model_ori.load_state_dict(torch.load(args.load)['state_dict'][0])
+        model_ori.load_state_dict(torch.load(args.load, map_location)['state_dict'][0])
     else:
-        model_ori.load_state_dict(torch.load(args.load))
+        model_ori.load_state_dict(torch.load(args.load, map_location))
         if args.model == "cnn_4layer_b":
             args.MODEL = "b_adv"
             assert args.data == "CIFAR_SAMPLE"


### PR DESCRIPTION
Hi there

Thanks a lot for publishing the code to your paper. I wanted to run your code on my local machine. I specified 'cpu' as the device argument. However I got the following error:

`RuntimeError: Attempting to deserialize object on a CUDA device but torch.cuda.is_available() is False. If you are running on a CPU-only machine, please use torch.load with map_location=torch.device('cpu') to map your storages to the CPU.`

I basically implemented just that suggestion. If 'cpu' is passed as the device, I also passed it to torch.load. It fixed the bug for me so I thought I'd open a PR. 

Feel free to use this or disregard it if you don't think it helps.

Cheers,
Claudio